### PR TITLE
"Fix missing newline at end of CSS file

### DIFF
--- a/client/src/styles/variables.css
+++ b/client/src/styles/variables.css
@@ -671,3 +671,5 @@
     --inner-shadow-500: inset 0 16px 16px -8px rgba(12 12 13 / 0.1);
     --inner-shadow-600: inset 0 16px 32px -8px rgba(12 12 13 / 0.4);
 }
+
+


### PR DESCRIPTION
Add a proper newline at the end of variables.css to comply with POSIX standards and improve file formatting consistency. This change helps prevent potential issues with tools or systems that rely on correctly formatted files."